### PR TITLE
fix: use addAllDocuments over upsertAllDocuments

### DIFF
--- a/modules/ai_engine_embedding/src/Form/AiEngineEmbeddingSettings.php
+++ b/modules/ai_engine_embedding/src/Form/AiEngineEmbeddingSettings.php
@@ -107,7 +107,7 @@ class AiEngineEmbeddingSettings extends ConfigFormBase {
    */
   public function actionUpsertAllDocuments(array &$form, FormStateInterface $form_state) {
     $service = \Drupal::service('ai_engine_embedding.entity_update');
-    $service->upsertAllDocuments();
+    $service->addAllDocuments();
   }
 
 }


### PR DESCRIPTION
It was found that when using the bulk add button on the form, it was actually calling a method that did not exist.  This changes it back to addAllDocuments so we can properly use it.

### Description of work
- Changes the referenced method execution from `upsertAllDocuments` to `addAllDocuments`