### PR TITLE
fix(upsert): use data_endpoint over data payload

### DIFF
--- a/modules/ai_engine_embedding/src/Service/EntityUpdate.php
+++ b/modules/ai_engine_embedding/src/Service/EntityUpdate.php
@@ -213,7 +213,8 @@ class EntityUpdate {
       "doctype" => "text",
       "service_name" => $config->get('azure_search_service_name'),
       "index_name" => $config->get('azure_search_service_index'),
-      "data" => $this->sources->getContentEndpoint($route_params),
+      "data" => "",
+      "data_endpoint" => $this->sources->getContentEndpoint($route_params),
     ];
     $httpClient = $this->httpClientFactory->fromOptions([
       'headers' => [


### PR DESCRIPTION
## Fix upsert to use `data_endpoint` over `data` for URL pass

The azure function is expecting a data_endpoint for the URL to queue up for pull after the cache has been regenerated.  This ensures that it receives the right data_endpoint entry.

### Description of work
- Changes the URL to get the JSON payload from `data` to `data_endpoint`

### Functional testing steps:
Note: This is currently implemented in the [finance site](https://askyale-ys-finance-ask-yale-edu.pantheonsite.io):
- [ ] Create a new node
- [ ] Ensure that the correct URL payload is sent to the Azure function
- [ ] Ensure it is able to use this to queue up a retrieval soon after, allowing enough time for cache to occur.

Once this goes through, we will revert finance so it can continue to keep up to date with versioning.