### PR TITLE
YSP-522: Separate permissions for admin and content settings

### DIFF
--- a/ai_engine.permissions.yml
+++ b/ai_engine.permissions.yml
@@ -1,4 +1,7 @@
 # Create permission for managin AI Engine settings.
 administer ai engine:
   title: 'Administer AI Engine'
-  description: 'Set and change AI Engine Settings.'
+  description: 'Enable services and change sensative settings.'
+manage ai engine settings:
+  title: 'Manage AI Engine Settings'
+  description: 'Set and update AI Engine content and settings.'

--- a/modules/ai_engine_chat/ai_engine_chat.links.menu.yml
+++ b/modules/ai_engine_chat/ai_engine_chat.links.menu.yml
@@ -1,7 +1,14 @@
-# Manage settings for the chat app.
+# Admin settings for the chat app.
+ai_engine_chat.admin:
+  title: 'Chat Admin'
+  description: 'Admin settings for the AI Engine chat service'
+  route_name: ai_engine_chat.admin
+  parent: ai_engine.admin
+  weight: 0
+# Manage content settings for the chat app.
 ai_engine_chat.settings:
   title: 'Chat Settings'
   description: 'Settings for the AI Engine chat service'
   route_name: ai_engine_chat.settings
   parent: ai_engine.admin
-  weight: 0
+  weight: 1

--- a/modules/ai_engine_chat/ai_engine_chat.routing.yml
+++ b/modules/ai_engine_chat/ai_engine_chat.routing.yml
@@ -1,8 +1,16 @@
+# Admin settings for the chat app.
+ai_engine_chat.admin:
+  path: '/admin/config/ai-engine/chat-admin'
+  defaults:
+    _form: '\Drupal\ai_engine_chat\Form\AiEngineChatAdmin'
+    _title: 'Chat Admin'
+  requirements:
+    _permission: 'administer ai engine'
 # Manage settings for the chat app.
 ai_engine_chat.settings:
-  path: '/admin/config/ai-engine/chat'
+  path: '/admin/config/ai-engine/chat-settings'
   defaults:
     _form: '\Drupal\ai_engine_chat\Form\AiEngineChatSettings'
     _title: 'Chat Settings'
   requirements:
-    _permission: 'administer ai engine'
+    _permission: 'manage ai engine settings'

--- a/modules/ai_engine_chat/src/Form/AiEngineChatAdmin.php
+++ b/modules/ai_engine_chat/src/Form/AiEngineChatAdmin.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\ai_engine_chat\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Admin form for the AI Engine Chat module.
+ */
+class AiEngineChatAdmin extends ConfigFormBase {
+
+  /**
+   * Config name.
+   *
+   * @var string
+   */
+  const CONFIG_NAME = 'ai_engine_chat.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ai_engine_chat_admin';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [self::CONFIG_NAME];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(self::CONFIG_NAME);
+    $form['enable'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable chat widget'),
+      '#default_value' => $config->get('enable') ?? FALSE,
+      '#description' => $this->t('Enable or disable chat service across the site. Chat can be launched by using the href="#launch-chat" on any link.'),
+    ];
+    $form['azure_base_url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Azure base URL'),
+      '#description' => $this->t('Ex: https://askyalehealth.azurewebsites.net'),
+      '#default_value' => $config->get('azure_base_url') ?? NULL,
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config(self::CONFIG_NAME)
+      ->set('enable', $form_state->getValue('enable'))
+      ->set('azure_base_url', $form_state->getValue('azure_base_url'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/ai_engine_chat/src/Form/AiEngineChatSettings.php
+++ b/modules/ai_engine_chat/src/Form/AiEngineChatSettings.php
@@ -36,18 +36,6 @@ class AiEngineChatSettings extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(self::CONFIG_NAME);
-    $form['enable'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Enable chat widget'),
-      '#default_value' => $config->get('enable') ?? FALSE,
-      '#description' => $this->t('Enable or disable chat service across the site. Chat can be launched by using the href="#launch-chat" on any link.'),
-    ];
-    $form['azure_base_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Azure base URL'),
-      '#description' => $this->t('Ex: https://askyalehealth.azurewebsites.net'),
-      '#default_value' => $config->get('azure_base_url') ?? NULL,
-    ];
     $form['prompts'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Initial Prompts'),
@@ -83,8 +71,6 @@ class AiEngineChatSettings extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->config(self::CONFIG_NAME)
-      ->set('enable', $form_state->getValue('enable'))
-      ->set('azure_base_url', $form_state->getValue('azure_base_url'))
       ->set('prompts', array_values(array_filter($form_state->getValue('prompts'))))
       ->set('disclaimer', $form_state->getValue('disclaimer'))
       ->set('footer', $form_state->getValue('footer'))

--- a/modules/ai_engine_embedding/ai_engine_embedding.links.menu.yml
+++ b/modules/ai_engine_embedding/ai_engine_embedding.links.menu.yml
@@ -4,4 +4,4 @@ ai_engine_embedding.settings:
   description: 'Settings for the AI Engine embedding service'
   route_name: ai_engine_embedding.settings
   parent: ai_engine.admin
-  weight: 0
+  weight: 10


### PR DESCRIPTION
## [YSP-522: AI: Separate permissions for admin and content settings](https://yaleits.atlassian.net/browse/YSP-522)

### Description of work
- Creates a new, lower level permission to "Manage AI Engine Settings"
- Splits the AI Chat admin into two forms to match permissions

### Functional testing steps:
- [x] Test admin role
  - [x] Add the "Administer AI Engine" to the site admin role
  - [x] Create a site admin user
  - [x] Login as this user and verify that you can edit the AI chat admin settings (/admin/config/ai-engine/chat-admin)
- [x] Test manage role
  - [x] Add the "Manage AI Engine Settings" to the site admin role. 
  - [x] Remove the "Administer AI Engine" permission.
  - [x] Login as the test user and verify that you can NOT edit the AI chat admin settings (/admin/config/ai-engine/chat-admin).
  - [x] Verify that the user can access the manage chat settings form (/admin/config/ai-engine/chat-settings)
