### PR TITLE
YSP-523: Allow AI metadata fields to be hidden

### DIFF
--- a/modules/ai_engine_metadata/ai_engine_metadata.links.menu.yml
+++ b/modules/ai_engine_metadata/ai_engine_metadata.links.menu.yml
@@ -1,0 +1,7 @@
+# Admin settings for the metadata service.
+ai_engine_metadata.admin:
+  title: 'Metadata Admin'
+  description: 'Admin settings for the AI Metadata service'
+  route_name: ai_engine_metadata.admin
+  parent: ai_engine.admin
+  weight: 20

--- a/modules/ai_engine_metadata/ai_engine_metadata.module
+++ b/modules/ai_engine_metadata/ai_engine_metadata.module
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * @file
  * Contains ai_engine_metadata.module functions.
@@ -8,18 +10,11 @@
 /**
  * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  */
-// function ai_engine_metadata_field_widget_complete_form_alter(&$field_widget_complete_form, \Drupal\Core\Form\FormStateInterface $form_state, $context) {
-
-function ai_engine_metadata_field_widget_complete_form_alter(&$field_widget_complete_form, \Drupal\Core\Form\FormStateInterface $form_state, $context) {
-  $field_definition = $context['items']->getFieldDefinition();
-  ksm($field_widget_complete_form);
-  ksm($field_definition->getType());
-  if($field_definition->getType() == 'metatag') {
-    // If the chat widget is enbabled, then attach the React app and related
-    // content to all pages and pass configuration via drupalSettings.
-    $config = \Drupal::config('ai_engine_metadata.settings');
-    if (!$config->get('enable')) {
-      unset($field_widget_complete_form['ai_engine']);
-    }
+function ai_engine_metadata_field_widget_single_element_metatag_firehose_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
+  // Only display the AI metatags form if it enabled in the admin interface.
+  // See: admin/config/ai-engine/metadata-admin.
+  $config = \Drupal::config('ai_engine_metadata.settings');
+  if (!$config->get('enable')) {
+    unset($field_widget_complete_form['ai_engine']);
   }
 }

--- a/modules/ai_engine_metadata/ai_engine_metadata.module
+++ b/modules/ai_engine_metadata/ai_engine_metadata.module
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Contains ai_engine_metadata.module functions.
+ */
+
+/**
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
+ */
+// function ai_engine_metadata_field_widget_complete_form_alter(&$field_widget_complete_form, \Drupal\Core\Form\FormStateInterface $form_state, $context) {
+
+function ai_engine_metadata_field_widget_complete_form_alter(&$field_widget_complete_form, \Drupal\Core\Form\FormStateInterface $form_state, $context) {
+  $field_definition = $context['items']->getFieldDefinition();
+  ksm($field_widget_complete_form);
+  ksm($field_definition->getType());
+  if($field_definition->getType() == 'metatag') {
+    // If the chat widget is enbabled, then attach the React app and related
+    // content to all pages and pass configuration via drupalSettings.
+    $config = \Drupal::config('ai_engine_metadata.settings');
+    if (!$config->get('enable')) {
+      unset($field_widget_complete_form['ai_engine']);
+    }
+  }
+}

--- a/modules/ai_engine_metadata/ai_engine_metadata.routing.yml
+++ b/modules/ai_engine_metadata/ai_engine_metadata.routing.yml
@@ -1,0 +1,8 @@
+# Admin settings for the metadata features.
+ai_engine_metadata.admin:
+  path: '/admin/config/ai-engine/metadata-admin'
+  defaults:
+    _form: '\Drupal\ai_engine_metadata\Form\AiEngineMetadataAdmin'
+    _title: 'Metadata Admin'
+  requirements:
+    _permission: 'administer ai engine'

--- a/modules/ai_engine_metadata/config/install/ai_engine_metadata.settings.yml
+++ b/modules/ai_engine_metadata/config/install/ai_engine_metadata.settings.yml
@@ -1,0 +1,1 @@
+enable: false

--- a/modules/ai_engine_metadata/src/Form/AiEngineMetadataAdmin.php
+++ b/modules/ai_engine_metadata/src/Form/AiEngineMetadataAdmin.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\ai_engine_metadata\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Admin form for the AI Engine Metadata module.
+ */
+class AiEngineMetadataAdmin extends ConfigFormBase {
+
+  /**
+   * Config name.
+   *
+   * @var string
+   */
+  const CONFIG_NAME = 'ai_engine_metadata.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ai_engine_metadata_admin';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [self::CONFIG_NAME];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(self::CONFIG_NAME);
+    $form['enable'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable AI Metadata features'),
+      '#default_value' => $config->get('enable') ?? FALSE,
+      '#description' => $this->t('Enable or disable AI metadata tools across the site.'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config(self::CONFIG_NAME)
+      ->set('enable', $form_state->getValue('enable'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
## [YSP-523: Allow AI metadata fields to be hidden](https://yaleits.atlassian.net/browse/YSP-523)

### Description of work
- We plan to enable all AI Engine modules across YaleSites. While these modules are enabled, they will not do anything by default. This is part of the YaleSite’s secret menu, where platform administrators can configure these services for site owners.
- The Embedding and Chat modules already have a master switch. Add another one for the AI Metadata to hide the interface from site admins by default.

### Functional testing steps:
- [x] Setup the AI metatags for your website
  - [x] Navigate the metatag settings interface (admin/config/search/metatag/settings)
  - [x] In the "Entity type / Group Mapping" section, enable "AI Metadata" for all content types and 'Save Configuration'.
- [x] Verify the new config form exists in the admin menu at: Configuration / AI Engine / Metadata Admin.
- [x] Visit this interface an make sure that "Enable AI Metadata features" is disabled.
- [x] Edit any nodes and view the "Metatag" section in the node details pane. Verify that the AI Metadata fields do not appear.
- [x] Return to the admin form and enable this feature.
- [x] Edit any node again. This you should see the AI Metadata fields.
