### PR TITLE
YSP-539: Bypass field_metatags if they don't exist

### DIFF
--- a/modules/ai_engine_feed/ai_engine_feed.services.yml
+++ b/modules/ai_engine_feed/ai_engine_feed.services.yml
@@ -2,4 +2,4 @@ services:
   # Service to query and prepare content for the feed.
   ai_engine_feed.sources:
     class: Drupal\ai_engine_feed\Service\Sources
-    arguments: ['@entity_type.manager', '@logger.channel.default', '@renderer', '@request_stack', '@ai_engine_metadata.manager']
+    arguments: ['@entity_type.manager', '@logger.channel.default', '@renderer', '@request_stack', '@ai_engine_metadata.manager', '@entity_field.manager']

--- a/modules/ai_engine_feed/src/ApiLinkBuilderTrait.php
+++ b/modules/ai_engine_feed/src/ApiLinkBuilderTrait.php
@@ -82,7 +82,7 @@ trait ApiLinkBuilderTrait {
       return "";
     }
     elseif ($totalPages > 1 && $currentPage < $totalPages) {
-      $params['page']++;
+      $params['page'] = $params['page'] ? $params['page']++ : 2;
     }
     return $this->getContentEndpoint($params);
   }

--- a/modules/ai_engine_feed/src/Service/Sources.php
+++ b/modules/ai_engine_feed/src/Service/Sources.php
@@ -248,9 +248,15 @@ class Sources {
    *   The rendered HTML.
    */
   protected function processContentBody(EntityInterface $entity) {
-    $view_builder = $this->entityTypeManager->getViewBuilder($entity->getEntityTypeId());
-    $renderArray = $view_builder->view($entity, 'default');
-    return $this->renderer->render($renderArray);
+    try {
+      $view_builder = $this->entityTypeManager->getViewBuilder($entity->getEntityTypeId());
+      $renderArray = $view_builder->view($entity, 'default');
+      $returnValue = $this->renderer->render($renderArray);
+    } catch(\TypeError $e) {
+      $returnValue = '';
+    }
+
+    return $returnValue;
   }
 
   /**


### PR DESCRIPTION
## [YSP-539: Bypass field_metatags if they don't exist](https://yaleits.atlassian.net/browse/YSP-539)

This is a first pass, where if the metatags field is not defined on the nodes, we do not use it.  Otherwise, we will use it.

Next up will be defining the metatags name to check against, if any.

### Description of work
- Adds a check whether `field_metatags` is defined in the field definitions
  - If not, it does not add the conditionals for AI excluded

### Functional testing steps:
- [ ] Bring up a new D10 site
- [ ] Install ai_module
- [ ] Turn on everything and set it up
- [ ] Attempt to visit the feed at /api/ai/v1/content
- [ ] Verify it loads with data
- [ ] Bring up a YaleSite that has field_metatags
- [ ] Install ai_module
- [ ] Turn on everything and set it up
- [ ] Set a node to be AI excluded
- [ ] Attempt to visit the feed at /api/ai/v1/content
- [ ] Verify it does not load that node
