### PR TITLE
YSP-539: Feed metatag settings

### DIFF
--- a/modules/ai_engine_feed/ai_engine_feed.links.menu.yml
+++ b/modules/ai_engine_feed/ai_engine_feed.links.menu.yml
@@ -1,0 +1,7 @@
+# Manage settings for the feed module
+ai_engine_feed.settings:
+  title: 'Feed Settings'
+  description: 'Settings for the AI Engine feed module'
+  route_name: ai_engine_feed.settings
+  parent: ai_engine.admin
+  weight: 0

--- a/modules/ai_engine_feed/ai_engine_feed.routing.yml
+++ b/modules/ai_engine_feed/ai_engine_feed.routing.yml
@@ -6,3 +6,10 @@ ai_engine_feed.content:
     _title: 'Content Feed'
   requirements:
     _permission: 'access content'
+ai_engine_feed.settings:
+  path: '/admin/config/ai-engine/feed'
+  defaults:
+    _form: '\Drupal\ai_engine_feed\Form\AiEngineFeedSettings'
+    _title: 'Feed Settings'
+  requirements:
+    _permission: 'administer ai engine'

--- a/modules/ai_engine_feed/ai_engine_feed.services.yml
+++ b/modules/ai_engine_feed/ai_engine_feed.services.yml
@@ -2,4 +2,4 @@ services:
   # Service to query and prepare content for the feed.
   ai_engine_feed.sources:
     class: Drupal\ai_engine_feed\Service\Sources
-    arguments: ['@entity_type.manager', '@logger.channel.default', '@renderer', '@request_stack', '@ai_engine_metadata.manager', '@entity_field.manager']
+    arguments: ['@entity_type.manager', '@logger.channel.default', '@renderer', '@request_stack', '@ai_engine_metadata.manager', '@entity_field.manager', '@config.factory']

--- a/modules/ai_engine_feed/src/Form/AiEngineFeedSettings.php
+++ b/modules/ai_engine_feed/src/Form/AiEngineFeedSettings.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\ai_engine_feed\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Setting form for the AI Engine Feed module.
+ */
+class AiEngineFeedSettings extends ConfigFormBase {
+  /**
+   * Config name.
+   *
+   * @var string
+   */
+  const CONFIG_NAME = 'ai_engine_feed.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ai_engine_feed_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [self::CONFIG_NAME];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(self::CONFIG_NAME);
+
+    $form['metatags_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Metatags field'),
+      '#default_value' => 'field_metatags',
+      '#description' => $this->t('The field name for storing metatags related to AI.'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Attempt to find the metatags field entered if they entered one.
+    $metatags_field = $form_state->getValue('metatags_field');
+    if (!empty($metatags_field)) {
+      $field_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config')->load('node.' . $metatags_field);
+      if (empty($field_storage)) {
+      $form_state->setErrorByName('metatags_field', $this->t('Field @field does not exist.', ['@field' => $metatags_field]));
+      }
+    }
+
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config(self::CONFIG_NAME)
+      ->set('metatags_field', $form_state->getValue('metatags_field'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/ai_engine_feed/src/Form/AiEngineFeedSettings.php
+++ b/modules/ai_engine_feed/src/Form/AiEngineFeedSettings.php
@@ -35,11 +35,20 @@ class AiEngineFeedSettings extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(self::CONFIG_NAME);
+    $possibleMetatags = $this->getAllMetatagsFields();
+    $defaultMetatag = "field_metatags";
+
+    $defaultValue = '';
+
+    if (isset($possibleMetatags[$defaultMetatag])) {
+      $defaultValue = $defaultMetatag;
+    }
 
     $form['metatags_field'] = [
-      '#type' => 'textfield',
+      '#type' => 'select',
+      '#options' => $this->getAllMetatagsFields(),
       '#title' => $this->t('Metatags field'),
-      '#default_value' => 'field_metatags',
+      '#default_value' => $config->get('metatags_field') ?? $defaultValue,
       '#description' => $this->t('The field name for storing metatags related to AI.'),
     ];
 
@@ -55,7 +64,7 @@ class AiEngineFeedSettings extends ConfigFormBase {
     if (!empty($metatags_field)) {
       $field_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config')->load('node.' . $metatags_field);
       if (empty($field_storage)) {
-      $form_state->setErrorByName('metatags_field', $this->t('Field @field does not exist.', ['@field' => $metatags_field]));
+        $form_state->setErrorByName('metatags_field', $this->t('Field @field does not exist.', ['@field' => $metatags_field]));
       }
     }
 
@@ -70,6 +79,30 @@ class AiEngineFeedSettings extends ConfigFormBase {
       ->set('metatags_field', $form_state->getValue('metatags_field'))
       ->save();
     parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Get all metatags to display to the user.
+   */
+  protected function getAllMetatagsFields() {
+    $fields = $this->appendNoMetatagEntry([]);
+    $metatagsList = \Drupal::service('entity_field.manager')->getFieldMapByFieldType('metatag');
+
+    foreach ($metatagsList as $entity_type => $fieldsList) {
+      foreach ($fieldsList as $field_name => $field) {
+        $fields[$field_name] = $field_name;
+      }
+    }
+
+    return $fields;
+  }
+
+  /**
+   * Append the no metatag entry to the list of metatags.
+   */
+  protected function appendNoMetatagEntry($fields) {
+    $fields[''] = 'Do not use metatags';
+    return $fields;
   }
 
 }


### PR DESCRIPTION
## [YSP-539: Feed metatag settings](https://yaleits.atlassian.net/browse/YSP-539)

Note: This piggybacks on [YSP-539: Bypass field_metatags if they don't exist](https://github.com/yalesites-org/ai_engine/pull/8), which handled the bypassing of a metatags field if it did not exist.  It attempts to fix #5.

### Description of work
- Adds config for meta tag field to feeds module
- Uses this config entry to drive whether to attempt to exclude nodes based on meta tag

### Functional testing steps:
- [ ] Log in as admin
- [ ] Ensure ai_modules extensions are enabled
- [ ] Visit Configuration->AI Engine->Feed Settings
- [ ] Select a meta tag from the drop down
- [ ] Use that meta tag to exclude a node
- [ ] Visit /api/ai/v1/content
- [ ] Verify the node is not in the list
- [ ] Go back to Configuration->AI Engine->Feed Settings
- [ ] Select "Do not use metatags"
- [ ] Save
- [ ] Visit /api/ai/v1/content
- [ ] Verify that the node previously excluded is now included
