### PR TITLE
fix(YSP-539): be explicit about increment

### DIFF
--- a/modules/ai_engine_feed/src/ApiLinkBuilderTrait.php
+++ b/modules/ai_engine_feed/src/ApiLinkBuilderTrait.php
@@ -82,7 +82,7 @@ trait ApiLinkBuilderTrait {
       return "";
     }
     elseif ($totalPages > 1 && $currentPage < $totalPages) {
-      $params['page'] = $params['page'] ? $params['page']++ : 2;
+      $params['page'] = $params['page'] ? ($params['page'] + 1) : 2;
     }
     return $this->getContentEndpoint($params);
   }


### PR DESCRIPTION
## [YSP-539: Add explicit increment](https://yaleits.atlassian.net/browse/YSP-539)

Instead of using post-increment, be explicit about when it increments. Also, not sure why this worked in the first place since the original code had post-increment.  This will now allow "next" to point to the next page.

### Description of work
- Replaced `$params['page']++` with `($params['page'] + 1)`

### Functional testing steps:
- [ ] Visit the api content page, passing it a page value
- [ ] Ensure that the "next" variable in the output at the bottom is indeed the next incremented page