### PR TITLE
YSP-592: AI: Content endpoint uses it's title for each node render

### DIFF
--- a/modules/ai_engine_feed/src/Service/Sources.php
+++ b/modules/ai_engine_feed/src/Service/Sources.php
@@ -270,6 +270,7 @@ class Sources {
    */
   protected function processContentBody(EntityInterface $entity) {
     try {
+      $this->setRequestTitleToNodeTitle();
       $view_builder = $this->entityTypeManager->getViewBuilder($entity->getEntityTypeId());
       $renderArray = $view_builder->view($entity, 'default');
       $returnValue = $this->renderer->render($renderArray);
@@ -328,6 +329,23 @@ class Sources {
    */
   protected function getUrl(EntityInterface $entity): string {
     return $entity->toUrl('canonical', ['absolute' => TRUE])->toString();
+  }
+
+  /**
+   * Set the request title to the node title.
+   *
+   * @return bool
+   *  TRUE if the request title was set.
+   */
+  protected function setRequestTitleToNodeTitle(): boolean {
+    $request = $this->requestStack->getCurrentRequest();
+    $node = $request->attributes->get('node');
+    if ($node) {
+      $request->attributes->set('title', $node->getTitle());
+      return true;
+    }
+
+    return false;
   }
 
 }


### PR DESCRIPTION
## [YSP-592: AI: Content endpoint uses it's title for each node render](https://yaleits.atlassian.net/browse/YSP-592)

When meta blocks render, they attempt to use the request object to get the title of the route.  In the case of visiting a page, this works as intended, but in the case of our AI content endpoint, it resolves to that endpoint, resulting in the title always being 'Content Feed', since that is the title of that endpoint.

This temporarily sets the route's title to the node's title so that the render can successfully occur using the correct title.

### Description of work
- During the render loop, it replaces the route's title temporarily with the node's title so that meta blocks can pick it up

### Functional testing steps:
- [ ] Visit /api/ai/v1/content
- [ ] Verify a search for "Content Feed" yields no results
