### PR TITLE
YSP-610: add `chunk_size` to API call

### DIFF
--- a/modules/ai_engine_embedding/src/Form/AiEngineEmbeddingSettings.php
+++ b/modules/ai_engine_embedding/src/Form/AiEngineEmbeddingSettings.php
@@ -60,6 +60,12 @@ class AiEngineEmbeddingSettings extends ConfigFormBase {
       '#description' => $this->t('Ex: https://askyaleindexfunc.azurewebsites.net'),
       '#default_value' => $config->get('azure_embedding_service_url') ?? NULL,
     ];
+    $form['azure_chunk_size'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Chunk Size'),
+      '#description' => $this->t('The chunk size to split each document into'),
+      '#default_value' => $config->get('azure_chunk_size') ?? 3000,
+    ];
     $form['actions'] = [
       '#type' => 'details',
       '#title' => $this->t('Embedding Operations'),
@@ -98,6 +104,7 @@ class AiEngineEmbeddingSettings extends ConfigFormBase {
       ->set('azure_search_service_name', $form_state->getValue('azure_search_service_name'))
       ->set('azure_search_service_index', $form_state->getValue('azure_search_service_index'))
       ->set('azure_embedding_service_url', $form_state->getValue('azure_embedding_service_url'))
+      ->set('azure_chunk_size', $form_state->getValue('azure_chunk_size'))
       ->save();
     parent::submitForm($form, $form_state);
   }

--- a/modules/ai_engine_embedding/src/Form/AiEngineEmbeddingSettings.php
+++ b/modules/ai_engine_embedding/src/Form/AiEngineEmbeddingSettings.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\ai_engine_embedding\Form;
 
+use Drupal\ai_engine_embedding\Service\EntityUpdate;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 
@@ -99,12 +100,18 @@ class AiEngineEmbeddingSettings extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $azure_chunk_size = $form_state->getValue('azure_chunk_size') ?? EntityUpdate::CHUNK_SIZE_DEFAULT;
+
+    if (!is_numeric($azure_chunk_size) || $azure_chunk_size < 1) {
+      $azure_chunk_size = EntityUpdate::CHUNK_SIZE_DEFAULT;
+    }
+
     $this->config(self::CONFIG_NAME)
       ->set('enable', $form_state->getValue('enable'))
       ->set('azure_search_service_name', $form_state->getValue('azure_search_service_name'))
       ->set('azure_search_service_index', $form_state->getValue('azure_search_service_index'))
       ->set('azure_embedding_service_url', $form_state->getValue('azure_embedding_service_url'))
-      ->set('azure_chunk_size', $form_state->getValue('azure_chunk_size'))
+      ->set('azure_chunk_size', $azure_chunk_size)
       ->save();
     parent::submitForm($form, $form_state);
   }

--- a/modules/ai_engine_embedding/src/Service/EntityUpdate.php
+++ b/modules/ai_engine_embedding/src/Service/EntityUpdate.php
@@ -14,6 +14,7 @@ use Drupal\metatag\MetatagManager;
  * Service for updating the vector database as content is updated.
  */
 class EntityUpdate {
+  const CHUNK_SIZE_DEFAULT = 3000;
 
   /**
    * The configuration factory.
@@ -150,6 +151,7 @@ class EntityUpdate {
    */
   public function addAllDocuments() {
     $config = $this->configFactory->get('ai_engine_embedding.settings');
+    $chunk_size = $config->get('azure_chunk_size') || CHUNK_SIZE_DEFAULT;
     $data = [
       "action" => "upsert",
       "doctype" => "text",
@@ -157,6 +159,7 @@ class EntityUpdate {
       "index_name" => $config->get('azure_search_service_index'),
       "data" => "",
       "data_endpoint" => $this->sources->getContentEndpoint(),
+      "chunk_size" => $chunk_size,
     ];
     $httpClient = $this->httpClientFactory->fromOptions([
       'headers' => [
@@ -204,6 +207,7 @@ class EntityUpdate {
    */
   public function upsertDocument(EntityInterface $entity) {
     $config = $this->configFactory->get('ai_engine_embedding.settings');
+    $chunk_size = $config->get('azure_chunk_size') || CHUNK_SIZE_DEFAULT;
     $route_params = [
       'entityType' => $entity->getEntityTypeId(),
       'id' => $entity->id(),
@@ -215,6 +219,7 @@ class EntityUpdate {
       "index_name" => $config->get('azure_search_service_index'),
       "data" => "",
       "data_endpoint" => $this->sources->getContentEndpoint($route_params),
+      "chunk_size" => $chunk_size,
     ];
     $httpClient = $this->httpClientFactory->fromOptions([
       'headers' => [


### PR DESCRIPTION
## [YSP-610: add `chunk_size` to API call](https://yaleits.atlassian.net/browse/YSP-610)

### Description of work
- Adds `chunk_size` as a configurable item in embedding settings
- Pass that `chunk_size` to API endpoints through the JSON payload
- Default empty chunk_sizes to 3000

### Functional testing steps:
- [ ] Use an [echo server](https://github.com/dblanken-yale/echo-server) to point to
  - [ ] Bring down repo
  - [ ] `node server.js`
- [ ] Bring a yalesite locally
- [ ] Update ai_module to use this branch
- [ ] Enable ai_module
- [ ] In the embedding configuration settings, set the settings to:
  - Enable embedding services: On
  - Azure Search Services Name: localhost
  - Azure Search Service Index: localhost
  - Azure Embedding Service Endpoint: http://host.docker.internal:3000
  - Chunk Size: 5000
- [ ] Note that the endpoint is actually Lando's host URL so it can get to the echo server above
  - [ ] To verify that address: `lando ssh -c "env" | grep LANDO_HOST_IP`
- [ ] Save the settings
- [ ] Visit a node and make a save on it
- [ ] Watch the payload the echo server returns to you
  - [ ] Verify that the chunk_size is 5000