### PR TITLE
YSP-756: Fix bad request NULL error

### DIFF
--- a/modules/ai_engine_embedding/src/Service/EntityUpdate.php
+++ b/modules/ai_engine_embedding/src/Service/EntityUpdate.php
@@ -173,7 +173,7 @@ class EntityUpdate {
 
       if (!$response) {
         $this->logger->notice(
-          'Unable to upsert to vector database. Response not successful.',
+          'Unable to upsert to vector database. Response not successful.  Check the Azure embedding service URL.',
         );
         return NULL;
       }
@@ -248,7 +248,7 @@ class EntityUpdate {
 
     if ($response === NULL) {
       $this->logger->notice(
-        'Unable to upsert node @id to vector database. Response not successful.  Could the azure embedding service URL be incorrect?',
+        'Unable to upsert node @id to vector database. Response not successful.  Check the Azure embedding service URL.',
         ['@id' => $entity->id()]
       );
       return NULL;

--- a/modules/ai_engine_embedding/src/Service/EntityUpdate.php
+++ b/modules/ai_engine_embedding/src/Service/EntityUpdate.php
@@ -162,12 +162,12 @@ class EntityUpdate {
    * a cleanup routine to find and delete out of date chunks.
    */
   public function addAllDocuments() {
-    $docTypes = ['node' => 'text', 'media' => 'media'];
+    $docType = "text";
     $config = $this->configFactory->get('ai_engine_embedding.settings');
 
     // Loop through entityTypesToSend and send.
     foreach (self::ALLOWED_ENTITIES as $entityType) {
-      $data = $this->getData("upsert", $config, ['entityType' => $entityType], "", $docTypes[$entityType]);
+      $data = $this->getData("upsert", $config, ['entityType' => $entityType], "", $docType);
       $endpoint = $config->get('azure_embedding_service_url') . '/api/upsert';
       $response = $this->sendJsonPost($endpoint, $data);
 

--- a/modules/ai_engine_embedding/src/Service/EntityUpdate.php
+++ b/modules/ai_engine_embedding/src/Service/EntityUpdate.php
@@ -429,6 +429,8 @@ class EntityUpdate {
    *   An array of route parameters.
    * @param string $data
    *   The data to send to the AI Embedding service.
+   * @param string $doctype
+   *   The type of document being sent to the AI Embedding service.
    *
    * @return array
    *   An array of data to send to the AI Embedding service.

--- a/modules/ai_engine_embedding/src/Service/EntityUpdate.php
+++ b/modules/ai_engine_embedding/src/Service/EntityUpdate.php
@@ -171,6 +171,13 @@ class EntityUpdate {
       $endpoint = $config->get('azure_embedding_service_url') . '/api/upsert';
       $response = $this->sendJsonPost($endpoint, $data);
 
+      if (!response) {
+        $this->logger->notice(
+          'Unable to upsert to vector database. Response not successful.',
+        );
+        return NULL;
+      }
+
       if ($response->getStatusCode() === 200) {
         $responseData = json_decode($response->getBody()->getContents(), TRUE);
         $this->logger->notice(

--- a/modules/ai_engine_embedding/src/Service/EntityUpdate.php
+++ b/modules/ai_engine_embedding/src/Service/EntityUpdate.php
@@ -248,7 +248,7 @@ class EntityUpdate {
 
     if ($response === NULL) {
       $this->logger->notice(
-        'Unable to upsert node @id to vector database. Response not successful',
+        'Unable to upsert node @id to vector database. Response not successful.  Could the azure embedding service URL be incorrect?',
         ['@id' => $entity->id()]
       );
       return NULL;

--- a/modules/ai_engine_embedding/src/Service/EntityUpdate.php
+++ b/modules/ai_engine_embedding/src/Service/EntityUpdate.php
@@ -173,7 +173,7 @@ class EntityUpdate {
 
       if (!$response) {
         $this->logger->notice(
-          'Unable to upsert to vector database. Response not successful.  Check the Azure embedding service URL.',
+          'Unable to upsert to vector database. Response not successful. Check the Azure embedding service URL.',
         );
         return NULL;
       }
@@ -248,7 +248,7 @@ class EntityUpdate {
 
     if ($response === NULL) {
       $this->logger->notice(
-        'Unable to upsert node @id to vector database. Response not successful.  Check the Azure embedding service URL.',
+        'Unable to upsert node @id to vector database. Response not successful. Check the Azure embedding service URL.',
         ['@id' => $entity->id()]
       );
       return NULL;

--- a/modules/ai_engine_embedding/src/Service/EntityUpdate.php
+++ b/modules/ai_engine_embedding/src/Service/EntityUpdate.php
@@ -171,7 +171,7 @@ class EntityUpdate {
       $endpoint = $config->get('azure_embedding_service_url') . '/api/upsert';
       $response = $this->sendJsonPost($endpoint, $data);
 
-      if (!response) {
+      if (!$response) {
         $this->logger->notice(
           'Unable to upsert to vector database. Response not successful.',
         );


### PR DESCRIPTION
## [YSP-756: Fix bad request NULL error](https://yaleits.atlassian.net/browse/YSP-756)

### Description of work
- Intercepts bad request so that it will not cause an error
- Forces `text` document types

### Functional testing steps:
- [ ] Visit [Test Multidev Embed Settings](https://pr-779-yalesites-platform.pantheonsite.io/admin/config/ai-engine/embedding) as user 1
- [ ] Click `Upsert all`
- [ ] Verify no errors occur
- [ ] Visit the logs to verify that the error states it couldn't get to the endpoint