### PR TITLE
YSP-796: AI: Bulk update PDFs fail

### DIFF
--- a/modules/ai_engine_feed/src/Service/Sources.php
+++ b/modules/ai_engine_feed/src/Service/Sources.php
@@ -219,6 +219,13 @@ class Sources {
       ->condition('status', NodeInterface::PUBLISHED)
       ->accessCheck(TRUE);
 
+    // For media, make sure we only pull those they chose to include.
+    // This should probably be extracted and injected.
+    if ($entityType === 'media') {
+      $allowedBundles = $this->configFactory->get('ai_engine_embedding.settings')->get('included_media_types');
+      $query->condition('bundle', $allowedBundles, 'IN');
+    }
+
     // Optionally page results.
     if ($pager) {
       $page = $params['page'] ?? 1;

--- a/modules/ai_engine_feed/src/Service/Sources.php
+++ b/modules/ai_engine_feed/src/Service/Sources.php
@@ -242,7 +242,7 @@ class Sources {
     $metatags_field = $this->configFactory->get(self::CONFIG_NAME)->get('metatags_field');
     if (!empty($metatags_field)) {
       $andCondition = $query->orConditionGroup()
-        ->condition($metatags_field, '%ai_disable_indexing%', 'NOT LIKE')
+        ->condition($metatags_field, '%ai_disable_indexing":"disabled%', 'NOT LIKE')
         ->condition($metatags_field, NULL, 'IS NULL');
       $query->condition($andCondition);
     }

--- a/modules/ai_engine_feed/src/Service/Sources.php
+++ b/modules/ai_engine_feed/src/Service/Sources.php
@@ -222,7 +222,7 @@ class Sources {
     // For media, make sure we only pull those they chose to include.
     // This should probably be extracted and injected.
     if ($entityType === 'media') {
-      $allowedBundles = $this->configFactory->get('ai_engine_embedding.settings')->get('included_media_types');
+      $allowedBundles = $this->configFactory->get('ai_engine_embedding.settings')->get('included_media_types') ?? [''];
       $query->condition('bundle', $allowedBundles, 'IN');
     }
 

--- a/modules/ai_engine_metadata/src/Plugin/Action/DisableAi.php
+++ b/modules/ai_engine_metadata/src/Plugin/Action/DisableAi.php
@@ -32,12 +32,12 @@ class DisableAi extends MetatagValueSetAction {
   /**
    * {@inheritdoc}
    */
-  protected static $entityMetatagFieldName = 'ai_disable_indexing';
+  protected static $entityMetatagFieldName = 'field_metatags';
 
   /**
    * {@inheritdoc}
    */
-  protected static $metatagFieldName = 'field_metatags';
+  protected static $metatagFieldName = 'ai_disable_indexing';
 
   /**
    * {@inheritdoc}

--- a/modules/ai_engine_metadata/src/Plugin/Action/EnableAi.php
+++ b/modules/ai_engine_metadata/src/Plugin/Action/EnableAi.php
@@ -32,12 +32,12 @@ class EnableAi extends MetatagValueSetAction {
   /**
    * {@inheritdoc}
    */
-  protected static $entityMetatagFieldName = 'ai_disable_indexing';
+  protected static $entityMetatagFieldName = 'field_metatags';
 
   /**
    * {@inheritdoc}
    */
-  protected static $metatagFieldName = 'field_metatags';
+  protected static $metatagFieldName = 'ai_disable_indexing';
 
   /**
    * {@inheritdoc}

--- a/modules/ai_engine_metadata/src/Plugin/Action/MetatagValueSetAction.php
+++ b/modules/ai_engine_metadata/src/Plugin/Action/MetatagValueSetAction.php
@@ -31,7 +31,7 @@ class MetatagValueSetAction extends ActionBase implements ContainerFactoryPlugin
   protected static $entityMetatagFieldName;
 
   /**
-   * The name of the metatag field to update.
+   * The name of the metatag field inside the entity field to update.
    *
    * @var string
    */
@@ -115,10 +115,10 @@ class MetatagValueSetAction extends ActionBase implements ContainerFactoryPlugin
     }
 
     if ($entity->hasField(static::$entityMetatagFieldName)) {
-      $metaTagsArray = json_decode($entity->field_metatags->value ?? "{}", TRUE);
+      $metaTagsArray = json_decode($entity->get(static::$entityMetatagFieldName)->value ?? "{}", TRUE);
       $metaTagsArray[static::$metatagFieldName] = static::$actionValue;
       $metaTagsJson = json_encode($metaTagsArray);
-      $entity->field_metatags->value = $metaTagsJson;
+      $entity->get(static::$entityMetatagFieldName)->value = $metaTagsJson;
       $entity->save();
     }
   }

--- a/modules/ai_engine_metadata/src/Plugin/metatag/Tag/AiDisableIndexing.php
+++ b/modules/ai_engine_metadata/src/Plugin/metatag/Tag/AiDisableIndexing.php
@@ -25,13 +25,25 @@ class AiDisableIndexing extends MetaNameBase {
    * {@inheritdoc}
    */
   public function form(array $element = []): array {
+    // There should always be a value here.
+    // But old entities might not have it set.
+    // So we need to set it to the default value.
+    if ($this->value == NULL) {
+      $this->value = $this->getDefaultValueForEntityType();
+    }
+
+    $checked = $this->value === 'disabled';
+
     $form = [
       '#type' => 'checkbox',
       '#title' => $this->label(),
       '#description' => $this->description(),
-      '#default_value' => ($this->value === 'disabled') ? 1 : 0,
+      '#default_value' => 'disabled',
       '#required' => $element['#required'] ?? FALSE,
       '#element_validate' => [[get_class($this), 'validateTag']],
+      '#attributes' => [
+        'checked' => $checked ? 'checked' : NULL,
+      ],
     ];
 
     return $form;
@@ -70,6 +82,24 @@ class AiDisableIndexing extends MetaNameBase {
     }
 
     parent::setValue($value);
+  }
+
+  /**
+   *
+   */
+  protected function getDefaultValueForEntityType(): string {
+    $request = $this->request;
+    // Get the attributes.
+    $entity_type_id = $request->attributes->get('entity_type_id') ?? '';
+
+    // If it's a media type, then it's $this->value or disabled.
+    // Otherwise, it's $this->value or enabled.
+    if ($entity_type_id === 'media') {
+      return 'disabled';
+    }
+    else {
+      return 'enabled';
+    }
   }
 
 }

--- a/modules/ai_engine_metadata/src/Plugin/metatag/Tag/AiDisableIndexing.php
+++ b/modules/ai_engine_metadata/src/Plugin/metatag/Tag/AiDisableIndexing.php
@@ -29,10 +29,9 @@ class AiDisableIndexing extends MetaNameBase {
       '#type' => 'checkbox',
       '#title' => $this->label(),
       '#description' => $this->description(),
-      '#default_value' => ($this->value === 'disabled') ?: '',
+      '#default_value' => ($this->value === 'disabled') ? 1 : 0,
       '#required' => $element['#required'] ?? FALSE,
       '#element_validate' => [[get_class($this), 'validateTag']],
-      '#return_value' => 'disabled',
     ];
 
     return $form;
@@ -57,6 +56,20 @@ class AiDisableIndexing extends MetaNameBase {
    */
   public function getTestOutputValuesXpath(array $values): array {
     return ["//" . $this->htmlTag . "[@" . $this->htmlNameAttribute . "='{$this->name}' and @content='disabled']"];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setValue($value): void {
+    if ($value == "1") {
+      $value = 'disabled';
+    }
+    elseif ($value == "0") {
+      $value = 'enabled';
+    }
+
+    parent::setValue($value);
   }
 
 }


### PR DESCRIPTION
## [YSP-796: AI: Bulk update PDFs fail](https://yaleits.atlassian.net/browse/YSP-796)

### Description of work
- Adds scoping to selected media types to include
- Fix bulk include/exclude
- Fix metatag enable/disable AI to have actual enabled/disabled values
- Created a way for media types to be excluded by default, while nodes are included by default

### Functional testing steps:
- [ ] Set up the embedding
- [ ] Add a PDF
- [ ] Ensure that the metatags default the PDF to be disabled for AI by default
- [ ] Change it and save a PDF
- [ ] Ensure it keeps that value in tact as. you change and save and re-edit
- [ ] Double check nodes do the opposite (include by default)
- [ ] Go in as user 1 and do a bulk update or visit the API location to verify that the correct media is being included
