### PR TITLE
YSP-850: Create auto chat open functionality

### DIFF
--- a/modules/ai_engine_chat/js/events.js
+++ b/modules/ai_engine_chat/js/events.js
@@ -7,15 +7,24 @@
  */
 document.addEventListener("DOMContentLoaded", function () {
   var launchLinks = document.querySelectorAll('a[href="#launch-chat"]');
+
   launchLinks.forEach(function (link) {
     link.classList.add("ai-chatbot");
     link.addEventListener("click", function (event) {
       event.preventDefault();
-      // Trigger a click on the button with id "launch-chat-modal".
-      var launchButton = document.getElementById("launch-chat-modal");
-      if (launchButton) {
-        launchButton.click();
-      }
+      triggerChatLaunch();
     });
   });
+
+  if (window.location.hash === "#launch-chat") {
+    setTimeout(triggerChatLaunch, 0);
+  }
+
+  function triggerChatLaunch() {
+    // Trigger a click on the button with id "launch-chat-modal".
+    var launchButton = document.getElementById("launch-chat-modal");
+    if (launchButton) {
+      launchButton.click();
+    }
+  }
 });


### PR DESCRIPTION
## [YSP-850: Create auto chat open functionality](https://yaleits.atlassian.net/browse/YSP-850)

### Description of work
- Introduced `triggerChatLaunch` function to encapsulate chat launch logic.
- Added support for auto-launching chat when URL hash is `#launch-chat`.
- Improved code readability and maintainability by refactoring.

### Functional testing steps:
- [ ] Enable the chat via the Chat admin settings
  - [ ] Make sure to use a valid endpoint
- [ ] Visit a page and place a link to the chat bot using `#launch-chat`
- [ ] Save
- [ ] Verify that the chat bot does not automatically open
- [ ] Edit the URL to append `#launch-chat` to the end
- [ ] Verify that the chat bot does automatically open
