### PR TITLE
Make chat widget text bold

### DIFF
--- a/modules/ai_engine_chat/css/chat_button.css
+++ b/modules/ai_engine_chat/css/chat_button.css
@@ -43,6 +43,7 @@
   line-height: 1.4;
   font-size: max(1rem, 16px);
   white-space: nowrap;
+  font-weight: bold;
 }
 
 /* Mobile: icon-only compact pill */


### PR DESCRIPTION
## Make chat widget text bold

### Description of work
- Makes chat widget text bold to match icon

### Functional testing steps:
- [ ] Ensure that the text seems bold enough to compliment the icon next to in the floating widget