### PR TITLE
feat(chat): fix code block overflow with copy button

### DIFF
--- a/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
+++ b/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
@@ -227,3 +227,11 @@ sup {
     font-size: 1rem;
     line-height: 1;
 }
+
+.answerText code:not(pre > code) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+  background: #f0f0f0;
+  border-radius: 3px;
+  padding: 0.2em 0.4em;
+}

--- a/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
+++ b/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
@@ -41,6 +41,7 @@
     white-space: normal;
     word-wrap: break-word;
     max-width: 800px;
+    width: 100%;
 }
 
 @media screen and (min-width:800px) {

--- a/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
+++ b/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
@@ -13,6 +13,10 @@
     transition: all 200ms ease-in-out;
 }
 
+.answerContainer :global(.ms-StackItem) {
+    width: 100%;
+}
+
 @media screen and (min-width:800px) {
     .answerContainer {
         padding: 1rem 1rem 2rem 4.5rem;

--- a/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
+++ b/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
@@ -229,9 +229,9 @@ sup {
 }
 
 .answerText code:not(pre > code) {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.9em;
-  background: #f0f0f0;
-  border-radius: 3px;
-  padding: 0.2em 0.4em;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.9em;
+    background: #f0f0f0;
+    border-radius: 3px;
+    padding: 0.2em 0.4em;
 }

--- a/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
+++ b/modules/ai_engine_chat/react/src/components/Answer/Answer.module.css
@@ -41,7 +41,6 @@
     white-space: normal;
     word-wrap: break-word;
     max-width: 800px;
-    width: 100%;
 }
 
 @media screen and (min-width:800px) {

--- a/modules/ai_engine_chat/react/src/components/Answer/Answer.tsx
+++ b/modules/ai_engine_chat/react/src/components/Answer/Answer.tsx
@@ -14,6 +14,7 @@ import remarkGfm from "remark-gfm";
 import supersub from 'remark-supersub'
 import { ThumbDislike20Filled, ThumbLike20Filled } from "@fluentui/react-icons";
 import { XSSAllowTags } from "../../constants/xssAllowTags";
+import CodeBlock from './CodeBlock';
 
 interface Props {
     answer: AskResponse;
@@ -212,6 +213,7 @@ export const Answer = ({
                         remarkPlugins={[remarkGfm, supersub]}
                         children={parsedAnswer.markdownFormatText}
                         className={styles.answerText}
+                        components={{ pre: CodeBlock }}
                     />
                 </Stack.Item>
             </Stack>

--- a/modules/ai_engine_chat/react/src/components/Answer/Answer.tsx
+++ b/modules/ai_engine_chat/react/src/components/Answer/Answer.tsx
@@ -207,7 +207,7 @@ export const Answer = ({
             )}
             <img className={styles.chatMessageAIMessageAvatar} src={aiAvatar} alt="Yale Logo" />
 
-                <Stack.Item grow styles={{ root: { width: '100%' } }}>
+                <Stack.Item grow>
                     <ReactMarkdown
                         linkTarget="_blank"
                         remarkPlugins={[remarkGfm, supersub]}

--- a/modules/ai_engine_chat/react/src/components/Answer/Answer.tsx
+++ b/modules/ai_engine_chat/react/src/components/Answer/Answer.tsx
@@ -207,7 +207,7 @@ export const Answer = ({
             )}
             <img className={styles.chatMessageAIMessageAvatar} src={aiAvatar} alt="Yale Logo" />
 
-                <Stack.Item grow>
+                <Stack.Item grow styles={{ root: { width: '100%' } }}>
                     <ReactMarkdown
                         linkTarget="_blank"
                         remarkPlugins={[remarkGfm, supersub]}

--- a/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.module.css
+++ b/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.module.css
@@ -5,7 +5,6 @@
     border: 1px solid #e0e0e0;
     border-radius: 4px;
     margin: 0.75rem 0;
-    overflow-x: auto;
 }
 
 .codeBlockWrapper pre {

--- a/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.module.css
+++ b/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.module.css
@@ -1,10 +1,12 @@
 .codeBlockWrapper {
     position: relative;
+    width: 100%;
     max-width: 100%;
     background: #f5f5f5;
     border: 1px solid #e0e0e0;
     border-radius: 4px;
     margin: 0.75rem 0;
+    overflow: hidden;
 }
 
 .codeBlockWrapper pre {

--- a/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.module.css
+++ b/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.module.css
@@ -6,7 +6,6 @@
     border: 1px solid #e0e0e0;
     border-radius: 4px;
     margin: 0.75rem 0;
-    overflow: hidden;
 }
 
 .codeBlockWrapper pre {

--- a/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.module.css
+++ b/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.module.css
@@ -1,0 +1,53 @@
+.codeBlockWrapper {
+    position: relative;
+    max-width: 100%;
+    background: #f5f5f5;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    margin: 0.75rem 0;
+    overflow-x: auto;
+}
+
+.codeBlockWrapper pre {
+    margin: 0;
+    padding: 2.5rem 1rem 1rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    white-space: pre;
+    overflow-x: auto;
+}
+
+.codeBlockWrapper code {
+    font-family: inherit;
+    font-size: inherit;
+    background: none;
+    padding: 0;
+}
+
+.copyButton {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    font-family: 'Mallory', sans-serif;
+    font-size: 0.75rem;
+    padding: 0.25rem 0.6rem;
+    background: #f0f0f0;
+    color: #444;
+    border: 1px solid #e0e0e0;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+    line-height: 1.4;
+}
+
+.copyButton:hover {
+    color: #286DC0;
+    border-color: #286DC0;
+    background: #f0f0f0;
+}
+
+.copyButton:focus-visible {
+    outline: 2px solid #286DC0;
+    outline-offset: 0.25rem;
+}

--- a/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.tsx
+++ b/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.tsx
@@ -24,17 +24,22 @@ const CodeBlock = ({ children, node, ...rest }: ComponentPropsWithoutRef<'pre'> 
 
     if (!navigator.clipboard) return;
 
-    await navigator.clipboard.writeText(codeContent);
-    setCopied(true);
+    try {
+      await navigator.clipboard.writeText(codeContent);
+      setCopied(true);
 
-    timerRef.current = setTimeout(() => {
-      setCopied(false);
-    }, 2000);
+      timerRef.current = setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch {
+      // Clipboard write failed (permission denied or other error) — no-op
+    }
   };
 
   return (
     <div className={styles.codeBlockWrapper}>
       <button
+        type="button"
         className={styles.copyButton}
         onClick={handleCopy}
         aria-label={copied ? 'Code copied' : 'Copy code'}

--- a/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.tsx
+++ b/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
+import styles from './CodeBlock.module.css';
+
+const CodeBlock = ({ children, node, ...rest }: ComponentPropsWithoutRef<'pre'> & { node?: unknown }) => {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    const child = Array.isArray(children) ? children[0] : children;
+    const childProps = React.isValidElement(child)
+      ? (child.props as { children?: unknown })
+      : null;
+    const codeContent =
+      childProps?.children != null ? String(childProps.children) : '';
+
+    if (!navigator.clipboard) return;
+
+    await navigator.clipboard.writeText(codeContent);
+    setCopied(true);
+
+    timerRef.current = setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <div className={styles.codeBlockWrapper}>
+      <button
+        className={styles.copyButton}
+        onClick={handleCopy}
+        aria-label={copied ? 'Code copied' : 'Copy code'}
+      >
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+      <pre {...rest}>{children}</pre>
+    </div>
+  );
+};
+
+export default CodeBlock;

--- a/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.tsx
+++ b/modules/ai_engine_chat/react/src/components/Answer/CodeBlock.tsx
@@ -28,6 +28,9 @@ const CodeBlock = ({ children, node, ...rest }: ComponentPropsWithoutRef<'pre'> 
       await navigator.clipboard.writeText(codeContent);
       setCopied(true);
 
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
       timerRef.current = setTimeout(() => {
         setCopied(false);
       }, 2000);


### PR DESCRIPTION
## Description of work
- Add `CodeBlock` custom renderer for `ReactMarkdown` that wraps fenced code blocks in a scrollable, visually distinct container
- Add one-click copy button to code blocks with 2-second "Copied!" confirmation feedback
- Fix code block overflow by targeting Fluent UI's `.ms-StackItem` via scoped CSS (`:global`) to constrain the flex item width
- Add inline code styling (single backtick) using `:not(pre > code)` to avoid double-styling block code

## Functional testing steps
- [ ] Send a prompt that produces a fenced code block (e.g., ask for an XML or code example)
- [ ] Verify the code block stays within the answer card bounds
- [ ] Verify long lines scroll horizontally rather than overflowing the modal
- [ ] Verify the "Copy" button appears in the top-right corner of the code block
- [ ] Click "Copy" and verify the label changes to "Copied!" for 2 seconds then resets
- [ ] Verify inline code (single backtick) has a distinct light gray background
- [ ] Verify the copy button is keyboard accessible (focus-visible outline visible on tab)

Closes yalesites-org/YaleSites-Internal#1141